### PR TITLE
ci: bump internal checkout to Node 24 (v6)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout toolkit repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: blaxel-ai/toolkit
         path: .bl-toolkit


### PR DESCRIPTION
The composite action ran `actions/checkout@v4` (Node 20), which surfaced the Node 20 deprecation warning in every workflow that uses bl-action. Bumps it to `checkout@v6` (SHA-pinned). Only stable checkout inputs are used (repository/path/clean/fetch-depth/fetch-tags), so behavior is unchanged.

Part of ENG-2458 (clearing Node 20 warnings in the bl-test sandbox workflows, which pin bl-action via this develop line).